### PR TITLE
feat: Add ENABLE_DOMAIN_FRONTING options for duckduckgo

### DIFF
--- a/main.go
+++ b/main.go
@@ -84,7 +84,7 @@ func chatWithDuckDuckGo(c *gin.Context, messages []struct {
 		"Pragma":          "no-cache",
 		"TE":              "trailers",
 	}
-	
+
 	statusURL := "https://duckduckgo.com/duckchat/v1/status"
 	chatURL := "https://duckduckgo.com/duckchat/v1/chat"
 	

--- a/main.go
+++ b/main.go
@@ -87,7 +87,7 @@ func chatWithDuckDuckGo(c *gin.Context, messages []struct {
 
 	statusURL := "https://duckduckgo.com/duckchat/v1/status"
 	chatURL := "https://duckduckgo.com/duckchat/v1/chat"
-	
+
 	// Some countries or regions require a domain fronting for direct access. 
 	domainFronting := os.Getenv("ENABLE_DOMAIN_FRONTING")
 	if domainFronting == "yes" {

--- a/main.go
+++ b/main.go
@@ -94,7 +94,7 @@ func chatWithDuckDuckGo(c *gin.Context, messages []struct {
 		return
 	}
  
-  req.Host="duckduckgo.com"
+	req.Host="duckduckgo.com"
   
 	req.Header.Set("x-vqd-accept", "1")
 	for key, value := range headers {
@@ -127,7 +127,7 @@ func chatWithDuckDuckGo(c *gin.Context, messages []struct {
 		return
 	}
 
-  req.Host="duckduckgo.com"
+	req.Host="duckduckgo.com"
 
 	req.Header.Set("x-vqd-4", vqd4)
 	for key, value := range headers {

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strconv"
 
 	"github.com/gin-gonic/gin"
 )
@@ -89,8 +90,12 @@ func chatWithDuckDuckGo(c *gin.Context, messages []struct {
 	chatURL := "https://duckduckgo.com/duckchat/v1/chat"
 
 	// Some countries or regions require a domain fronting for direct access. 
-	domainFronting := os.Getenv("ENABLE_DOMAIN_FRONTING")
-	if domainFronting == "yes" {
+	domainFrontingEnv := os.Getenv("ENABLE_DOMAIN_FRONTING")
+	domainFronting, err := strconv.ParseBool(domainFrontingEnv)
+	if err != nil {
+		domainFronting = false
+	}
+	if domainFronting {
  		statusURL = "https://duck.ai/duckchat/v1/status"
 		chatURL = "https://duck.ai/duckchat/v1/chat"
 	}
@@ -106,7 +111,7 @@ func chatWithDuckDuckGo(c *gin.Context, messages []struct {
 		req.Header.Set(key, value)
 	}
 
-	if domainFronting == "yes" {
+	if domainFronting {
 		// use duckduckgo.com as the value of Host, avoid HTTP 302 redirects
 		req.Host = "duckduckgo.com"
 	}
@@ -137,7 +142,7 @@ func chatWithDuckDuckGo(c *gin.Context, messages []struct {
 		return
 	}
 
-	if domainFronting == "yes" {
+	if domainFronting {
 		// use duckduckgo.com as the value of Host, avoid HTTP 302 redirects
 		req.Host = "duckduckgo.com"
 	}

--- a/main.go
+++ b/main.go
@@ -84,8 +84,8 @@ func chatWithDuckDuckGo(c *gin.Context, messages []struct {
 		"TE":              "trailers",
 	}
 
-	statusURL := "https://duckduckgo.com/duckchat/v1/status"
-	chatURL := "https://duckduckgo.com/duckchat/v1/chat"
+	statusURL := "https://duck.ai/duckchat/v1/status"
+	chatURL := "https://duck.ai/duckchat/v1/chat"
 
 	// get vqd_4
 	req, err := http.NewRequest("GET", statusURL, nil)
@@ -93,7 +93,9 @@ func chatWithDuckDuckGo(c *gin.Context, messages []struct {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-
+ 
+  req.Host="duckduckgo.com"
+  
 	req.Header.Set("x-vqd-accept", "1")
 	for key, value := range headers {
 		req.Header.Set(key, value)
@@ -124,6 +126,8 @@ func chatWithDuckDuckGo(c *gin.Context, messages []struct {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
+
+  req.Host="duckduckgo.com"
 
 	req.Header.Set("x-vqd-4", vqd4)
 	for key, value := range headers {


### PR DESCRIPTION
duckduckgo 不校验 SNI 名称。
GFW 采用 DNS 污染 + SNI 阻断影响 duckduckgo.com的正常连接。
duck.ai 在其证书的备用名称里，未被污染和 SNI 阻断，且符合 AI 主题。
使用 duck.ai 解决 DNS污染 和 SNI 阻断问题。
其他未污染和阻断地区也可正常使用此方法。